### PR TITLE
Allow non-modular includes depending on minizip headers

### DIFF
--- a/SBYZipArchive.podspec.json
+++ b/SBYZipArchive.podspec.json
@@ -19,7 +19,8 @@
   "libraries": "z",
   "requires_arc": true,
   "xcconfig": {
-    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) USE_FILE32API=1"
+    "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) USE_FILE32API=1",
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES": true
   },
   "platforms": {
     "ios": "6.0",


### PR DESCRIPTION
fix #4 

minizip headers import libz headers with non-modular syntax.
It cause errors imported by swift.
So, set `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES` to `true`
